### PR TITLE
feat: use gcloud v0 version and remove deprecated authent

### DIFF
--- a/setup-cloud/action.yml
+++ b/setup-cloud/action.yml
@@ -8,7 +8,9 @@ runs:
         aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
         aws-region: "eu-west-1"
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: '${{ env.CICD_ARTIFACTORY_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: 'pubstack-artifactory'
-        service_account_key: ${{ env.CICD_ARTIFACTORY_KEY }}


### PR DESCRIPTION
We did that because of warnings:
```
google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from: uses: 'google-github-actions/setup-gcloud@master' to: uses: 'google-github-actions/setup-gcloud@v0' Alternatively, you can pin to any git tag or git SHA in the repository.
--
"service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization
```
We tried to used it on aggregation processings:
https://github.com/pbstck/aggregation-processings/runs/5291687159?check_suite_focus=true